### PR TITLE
Various adjustments

### DIFF
--- a/vcardlib.py
+++ b/vcardlib.py
@@ -675,6 +675,11 @@ def normalize(vcard, selected_name, \
         del vcard.version
         logging.debug("\t\tremoved VERSION attribute")
 
+    # set PRODID
+    if hasattr(vcard, 'prodid'):
+        del vcard.prodid
+    vcard.add('prodid').value = 'https://github.com/mbideau/vcardtools'
+
     # overwrite names with the selected one
     if not do_not_overwrite_names:
         # remove all name fields

--- a/vcardlib.py
+++ b/vcardlib.py
@@ -680,6 +680,11 @@ def normalize(vcard, selected_name, \
         del vcard.prodid
     vcard.add('prodid').value = 'https://github.com/mbideau/vcardtools'
 
+    # set REV
+    if hasattr(vcard, 'rev'):
+        del vcard.rev
+    vcard.add('rev').value = '20221009T110000+0200'
+
     # overwrite names with the selected one
     if not do_not_overwrite_names:
         # remove all name fields

--- a/vcardlib.py
+++ b/vcardlib.py
@@ -685,6 +685,14 @@ def normalize(vcard, selected_name, \
         del vcard.rev
     vcard.add('rev').value = '20221009T110000+0200'
 
+    # These will weirdly conflict when merging, and I just don't consider them relevant
+    if hasattr(vcard, 'x-calypso-name'):
+        delattr(vcard, 'x-calypso-name')
+    if hasattr(vcard, 'x-evolution-file-as'):
+        delattr(vcard, 'x-evolution-file-as')
+    if hasattr(vcard, 'x-mozilla-html'):
+        delattr(vcard, 'x-mozilla-html')
+
     # overwrite names with the selected one
     if not do_not_overwrite_names:
         # remove all name fields

--- a/vcardlib.py
+++ b/vcardlib.py
@@ -809,6 +809,8 @@ def get_vcards_from_files(files, \
                 normalize(vcard, selected_name, do_not_overwrite_names,
                           mv_name_parenth_braces_to_note, do_not_remove_name_in_email)
 
+                selected_name = f_name
+
                 # force the full parsing of the vcard to prevent further crash
                 try:
                     vcard.serialize()

--- a/vcardtools.py
+++ b/vcardtools.py
@@ -238,7 +238,7 @@ def main():  # pylint: disable=too-many-statements,too-many-branches
                         # save the remaining attributes to the merged vCard
                         vcard_merge = build_vcard(attributes)
                         # write to the file
-                        write_vcard_to_file(vcard_merge, d_path + '.vcard')
+                        write_vcard_to_file(vcard_merge, d_path)
 
                     # group
                     else:
@@ -248,7 +248,7 @@ def main():  # pylint: disable=too-many-statements,too-many-branches
                             logging.debug("\t\t%s", key)
                             write_vcard_to_file(
                                 vcards[key],
-                                d_path + '/' + key.replace('/', '-') + '.vcard')
+                                d_path + '/' + key)
                 else: # should not happen
                     raise RuntimeError("Only one vcard in group '" + g_name + "' "
                                        "(should not happen)")
@@ -260,7 +260,7 @@ def main():  # pylint: disable=too-many-statements,too-many-branches
                 for key in vcards_not_grouped:
                     write_vcard_to_file(
                         vcards[key],
-                        args.dest_dir + '/' + key.replace('/', '-') + '.vcard')
+                        args.dest_dir + '/' + key)
 
         # no grouping
         elif vcards:
@@ -268,7 +268,7 @@ def main():  # pylint: disable=too-many-statements,too-many-branches
             # create vCard files not grouped in dest dir root
             logging.info("Creating '%d' not grouped vCard files (in root dir) ...", len(vcards))
             for key, vcard in vcards.items():
-                write_vcard_to_file(vcard, args.dest_dir + '/' + key.replace('/', '-') + '.vcard')
+                write_vcard_to_file(vcard, args.dest_dir + '/' + key.replace('/', '-'))
 
 
     # user CTRL-C


### PR DESCRIPTION
I've used this tool in a larger address book merging operation, thanks for providing it.

I had to make a few adjustments for it to work well on my use case -- none of which are ship-shape right now, but I though this would just as well work as one draft PR than a bunch of single wishlist issues.

What's in here varies by degree of reusability -- is there anything you'd deem generally useful?

* Preserving file names (hard-coded right now, this would need some conditional) -- this was useful for me because I could then move the files back onto the originals and do a `git diff` on them
* setting PRODID and REV -- useful as a first normalization step, before at merging they'd always show up as changes (so if I change things once, commit that, and then do the merging, the merging doesn't show artifacts of the tool change. The REV would probably need to be passed in, not sure how that's best done).
* I'm kicking out a few actually useless X- values ... might this be useful in a generalized "remove any attribute in this list" form?