### PR TITLE
Test: Improve robustness by comparing only the last line of error output

### DIFF
--- a/test/run_some_tests.sh
+++ b/test/run_some_tests.sh
@@ -80,7 +80,12 @@ find "$cases_dir" -maxdepth 1 -type d -not -path "$cases_dir" | while read -r ca
             expectations_matched=false
         else
             sed "s|$project_dir/\?||g" -i "$tmp_err" # normalize paths
-            if ! diff -q "$case_exp" "$tmp_err" >/dev/null 2>&1; then
+
+            # Extract the last line from both files
+            last_line_case_exp=$(tail -n 1 "$case_exp")
+            last_line_tmp_err=$(tail -n 1 "$tmp_err")
+
+            if [ "$last_line_case_exp" != "$last_line_tmp_err" ]; then
                 echo "$case_name: FAIL (expected file '$(basename "$case_exp")' differs)'"
                 expectations_matched=false
                 if [ "$DEBUG" = 'true' ]; then


### PR DESCRIPTION
Any change in the Python code alters the backtrace, causing the "Empty vCard" test to fail unnecessarily. The failure occurs unless the expected output file (test/cases/Empty vCard/expected/FAILURE) is updated to match the new backtrace, even though the actual issue remains unchanged.

This patch enhances the test by only comparing the last line of the error output:
`ValueError: Trying to select a name from an empty list of names`. This avoids fragile backtrace comparisons and focuses on the relevant error message.